### PR TITLE
Style Edit Component Dialog

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import uuid from 'uuid/v4';
 import { renderToString } from 'react-dom/server';
 import TreeView from './TreeView/TreeView';
 import TreeModal from './TreeView/TreeModal';
-import { isNumber } from 'lodash'; 
+import { isNumber } from 'lodash';
 import TreeAddChild from './TreeView/TreeAddChild';
 
 // Stores
@@ -27,7 +27,7 @@ export type AppProps = {
   generatedComponentStore: GeneratedComponentStore;
 }
 
-export type AppState = { 
+export type AppState = {
   selectedId: ComponentId;
   htmlOutput: string;
   id: string;
@@ -114,12 +114,19 @@ class App extends Component<AppProps, AppState> {
       <div id="main-wrapper">
         <div className="tree-view">
           <h2> Tree View: </h2>
-          <TreeView 
+          <TreeView
             selectedId={this.state.selectedId}
             onSelect={this.handleSelect}
             componentList={this.props.generatedComponentStore.components}
             componentTypes={this.props.componentStructureStore.componentStructures}
           />
+          <div>
+          <TreeAddChild
+            onAddComponent={this.handleAdd}
+            componentStructures={this.props.componentStructureStore.componentStructures}
+          />
+          <button onClick={this.generateHtml}>Generate HTML</button>
+        </div>
         </div>
         <div id="component-wrapper">
           <CompileComponents
@@ -140,13 +147,6 @@ class App extends Component<AppProps, AppState> {
               childComponentStructures={selectedChildComponentStructures}
             />
           }
-        </div>
-        <div>
-          <TreeAddChild
-            onAddComponent={this.handleAdd}
-            componentStructures={this.props.componentStructureStore.componentStructures}
-          />
-          <button onClick={this.generateHtml}>Generate HTML</button>
         </div>
         {htmlOut}
       </div>

--- a/src/TreeView/TreeAddChild.tsx
+++ b/src/TreeView/TreeAddChild.tsx
@@ -38,7 +38,7 @@ export default class TreeAddChild extends Component<TreeAddChildProps, TreeAddCh
     }));
     return (
       <Fragment>
-        <Select 
+        <Select menuPlacement="auto"
           value={this.state.selected}
           onChange={this.handleChange}
           options={options}

--- a/src/TreeView/TreeModal.module.css
+++ b/src/TreeView/TreeModal.module.css
@@ -1,5 +1,12 @@
 .modal {
-  background-color: cyan;
-  border: 2px solid black;
+  background-color: #dcdddf;
+  border: 1px solid #AAA;
   border-radius: 5px;
+
+  position: fixed;
+  bottom: 0.5rem;
+  right: 0.5rem;
+  min-width: 30%;
+  z-index: 10;
+  padding: 10px;
 }

--- a/src/TreeView/TreeModal.tsx
+++ b/src/TreeView/TreeModal.tsx
@@ -48,7 +48,7 @@ class TreeModal extends Component<TreeModalProps, any> {
           element
         ];
       }, [] as JSX.Element[]);
-    
+
     const handleParentComponentAdd = (propName: string) => (componentName: string) => this.props.onAddComponent(componentName, propName);
 
     const componentValuesEl = Object.entries(this.props.componentStructure.propertyTypes)

--- a/src/index.css
+++ b/src/index.css
@@ -15,8 +15,8 @@ code {
     monospace;
 }
 
-#modal {
-  width: 100px;
+.modal-container {
+  position: relative;
 }
 
 #main-wrapper {
@@ -26,9 +26,10 @@ code {
 }
 
 #component-wrapper {
-  padding: 130px;
+  padding: 30px;
   z-index: 10;
   width: 50%;
+  flex-grow: 2;
 }
 
 .tree-view {
@@ -38,7 +39,7 @@ code {
   padding-top: 20px;
   border-right: 1px solid #AAA;
   padding-left: 10px;
-  flex-grow: 2;
+  flex-grow: 1;
 }
 
 .tree-view h2 {


### PR DESCRIPTION
Makes the edit component dialog a floating box on the bottom right, and style it. Also makes menus drop down or up based on space.

For now, the add component menu is placed on the tree view. If we add a root component to all pages, it won't be necessary.